### PR TITLE
Revert "Register submodule `appfigures_py` using https"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/appfigures_py"]
 	path = submodules/appfigures_py
-	url = https://github.com/tmation/appfigures_py.git
+	url = git@github.com:tmation/appfigures_py.git


### PR DESCRIPTION
This reverts commit 99e3d44567abd5eb3baf792bc68f35f3fc5ccd73.

I made this change originally to make it work on my own machine. I suspect this change is what now causes the import failure in Heroku. 